### PR TITLE
Change post endpoint id data type

### DIFF
--- a/flight_log_be/tests/test_views.py
+++ b/flight_log_be/tests/test_views.py
@@ -187,6 +187,10 @@ class FlightCreationTestCase(TestCase):
 
         self.assertTrue(Flight.objects.filter(user=user).exists())
 
+        flight = Flight.objects.all().last()
+        data = json.loads(response.content)["data"]
+        self.assertEqual(data["id"], f"{flight.id}")
+
 
 class FlightCreationSadPathTestCase(TestCase):
     def test_sad_path_flight_creation(self):

--- a/flight_log_be/views.py
+++ b/flight_log_be/views.py
@@ -76,7 +76,7 @@ def flights(request, user):
             serializer.save()
             flight_data = {
                 "data": {
-                    "id": Flight.objects.last().id,
+                    "id": f"{Flight.objects.last().id}",
                     "type": "flight",
                     "attributes": serializer.data,
                 }


### PR DESCRIPTION
## Neccesary checkmarks:

    [x] All Tests are Passing in all environments

    [x] The code will run locally

## Type of change

    [] New feature
    [x] Bug Fix
    [] Refactor

## Description of Change:

    description:  updates the POST flights endpoint to return the id of the newly-created flight as a string instead of an integer value, and adds a test for this specific attribute and data type
    
## Requested feedback: 
    
    I'd like feedback on... N/A, unless this is somehow not performing correctly for others!

## Check the correct boxes

    [x] This broke nothing
    [] This broke some stuff
    [] This broke everything

## Testing Changes

    [] No Tests have been changed
    [x] Some Tests have been changed
    [] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:

    [x] My code has no unused/commented out code
    [x] My code has no breakpoints
    [x] I have reviewed my code
    [x] I have commented my code, particularly in hard-to-understand areas
    [x] I have fully tested my code

(For Fun!)Please Include a link to a gif of your feelings about this branch


Link:
